### PR TITLE
🐛 SEO 메타데이터 및 사이트맵 안정화

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,8 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const SITE_URL = 'https://blog.owen.kr';
+const postsDir = process.env.POSTS_DIR || path.join(process.cwd(), 'api/posts');
+
+function getPostEntries() {
+  if (!fs.existsSync(postsDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(postsDir)
+    .filter(file => file.endsWith('.md'))
+    .map(file => {
+      const slug = file.replace(/\.md$/, '');
+      const filePath = path.join(postsDir, file);
+      const lastmod = fs.statSync(filePath).mtime.toISOString();
+
+      return {
+        slug,
+        lastmod,
+      };
+    });
+}
+
+function getPostsIndexEntry() {
+  return {
+    loc: '/posts',
+    changefreq: 'daily',
+    priority: 0.8,
+  };
+}
+
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: 'https://blog.owen.kr',
+  siteUrl: SITE_URL,
   generateRobotsTxt: true,
-  canonicalBase: 'https://blog.owen.kr',
+  canonicalBase: SITE_URL,
   robotsTxtOptions: {
     policies: [
       {
@@ -11,4 +45,13 @@ module.exports = {
       },
     ],
   },
+  additionalPaths: async () => [
+    getPostsIndexEntry(),
+    ...getPostEntries().map(({ slug, lastmod }) => ({
+      loc: `/posts/${slug}`,
+      lastmod,
+      changefreq: 'weekly',
+      priority: 0.7,
+    })),
+  ],
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-page-custom-font */
 // 루트 레이아웃
+import { DEFAULT_DESCRIPTION, SITE_NAME, SITE_URL } from '@/lib/seo';
 import type { Metadata } from 'next';
 import { Noto_Sans_KR } from 'next/font/google';
 import Script from 'next/script';
@@ -14,8 +15,30 @@ const notoSansKR = Noto_Sans_KR({
 });
 
 export const metadata: Metadata = {
-  title: 'Ever.Log',
-  description: 'Ever.Log',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: DEFAULT_DESCRIPTION,
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: [{ url: '/favicon.ico' }],
+  },
+  twitter: {
+    card: 'summary',
+    title: SITE_NAME,
+    description: DEFAULT_DESCRIPTION,
+    images: ['/favicon.ico'],
+  },
   icons: {
     icon: '/favicon.ico',
   },
@@ -27,7 +50,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html>
+    <html lang="ko">
       <head>
         <link
           rel="preload"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,21 @@
 import { persona } from '@/lib/comment';
 import { formatLine } from '@/lib/formatter';
+import { createPageMetadata } from '@/lib/seo';
+import type { Metadata } from 'next';
 import Link from 'next/link';
+
+const HOME_DESCRIPTION = '프론트엔드 엔지니어 Owen의 개발 로그, 피드, 이력서를 한 곳에서 확인할 수 있습니다.';
+
+export const metadata: Metadata = {
+  ...createPageMetadata({
+    title: 'Ever.Log',
+    description: HOME_DESCRIPTION,
+    path: '/',
+  }),
+  title: {
+    absolute: 'Ever.Log',
+  },
+};
 
 export default function HomePage() {
   return (

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,16 +1,55 @@
 import AppMarkdown from '@/components/markdown/AppMarkdown';
 import { getPostBySlug } from '@/lib/posts';
+import { createPageMetadata } from '@/lib/seo';
+import type { Metadata } from 'next';
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
-type Props = {
+type PageProps = {
   params: Promise<{ slug: Post['slug'] }>;
 };
 
+const NOT_FOUND_DESCRIPTION = '요청한 게시글을 찾을 수 없습니다.';
+
 export const dynamic = 'force-dynamic';
 
-export default async function PostPage({ params }: Props) {
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const post = getPostBySlug(slug);
+
+  if (!post) {
+    return {
+      ...createPageMetadata({
+        title: 'Post Not Found',
+        description: NOT_FOUND_DESCRIPTION,
+        path: `/posts/${slug}`,
+      }),
+      robots: {
+        index: false,
+        follow: false,
+      },
+    };
+  }
+
+  const title = post.meta.title;
+  const description = post.meta.description || `${title} | Ever.Log`;
+  const canonical = `/posts/${post.slug}`;
+
+  return createPageMetadata({
+    title,
+    description,
+    path: canonical,
+    type: 'article',
+  });
+}
+
+export default async function PostPage({ params }: PageProps) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
 
   return (
     <article className="flex justify-center p-4">

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,6 +1,15 @@
 import PostList from '@/components/Post/PostList';
 import { getAllPosts } from '@/lib/posts';
+import { createPageMetadata } from '@/lib/seo';
 import Link from 'next/link';
+
+const POSTS_DESCRIPTION = 'Ever.Log의 전체 게시글 피드입니다. 태그와 정렬로 개발 기록을 탐색할 수 있습니다.';
+
+export const metadata = createPageMetadata({
+  title: 'Feed',
+  description: POSTS_DESCRIPTION,
+  path: '/posts',
+});
 
 export const dynamic = 'force-dynamic';
 

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,6 +1,13 @@
 import { persona } from '@/lib/comment';
 import { formatLine } from '@/lib/formatter';
+import { createPageMetadata } from '@/lib/seo';
 import Link from 'next/link';
+
+export const metadata = createPageMetadata({
+  title: 'Resume',
+  description: 'Owen의 경력, 프로젝트, 기술 스택을 정리한 Ever.Log 이력서 페이지',
+  path: '/resume',
+});
 
 const githubLink = 'https://github.com/owen-ever';
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -7,23 +7,45 @@ import matter from 'gray-matter';
 // POSTS_DIR 환경변수로 오버라이드 가능
 const postsDir = process.env.POSTS_DIR || path.join(process.cwd(), 'api/posts');
 
+function normalizePostDate(date: unknown): string {
+  if (date instanceof Date) {
+    return date.toISOString().slice(0, 10);
+  }
+
+  return typeof date === 'string' ? date : String(date ?? '');
+}
+
+function normalizePostMeta(data: Record<string, unknown>): PostMeta {
+  return {
+    ...data,
+    date: normalizePostDate(data.date),
+  } as PostMeta;
+}
+
 export function getPostSlugs(): Post['slug'][] {
+  if (!fs.existsSync(postsDir)) {
+    return [];
+  }
+
   return fs
     .readdirSync(postsDir)
     .filter(file => file.endsWith('.md'))
     .map(file => file.replace(/\.md$/, ''));
 }
 
-export function getPostBySlug(slug: Post['slug']): Post {
+export function getPostBySlug(slug: Post['slug']): Post | null {
   const filePath = path.join(postsDir, `${slug}.md`);
-  // console.log('>>>> 1', filePath);
+
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
   const fileContents = fs.readFileSync(filePath, 'utf8');
-  // console.log('>>>> 2', fileContents);
   const { data, content } = matter(fileContents);
 
   return {
     slug,
-    meta: data as PostMeta,
+    meta: normalizePostMeta(data),
     content,
   };
 }
@@ -31,6 +53,7 @@ export function getPostBySlug(slug: Post['slug']): Post {
 export function getAllPosts(): Post[] {
   return getPostSlugs()
     .map(slug => getPostBySlug(slug))
+    .filter((post): post is Post => post !== null)
     .sort((a, b) => {
       if (a.meta.date === b.meta.date) {
         return a.meta.index < b.meta.index ? 1 : -1;

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+
+export const SITE_URL = 'https://blog.owen.kr';
+export const SITE_NAME = 'Ever.Log';
+export const DEFAULT_DESCRIPTION = '프론트엔드 엔지니어 Owen의 기술 기록을 담은 Ever.Log 블로그';
+
+type CreatePageMetadataInput = {
+  title: string;
+  description: string;
+  path: string;
+  type?: 'website' | 'article';
+};
+
+function normalizePath(path: string): string {
+  if (path === '/') {
+    return '/';
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+export function createPageMetadata({ title, description, path, type = 'website' }: CreatePageMetadataInput): Metadata {
+  const normalizedPath = normalizePath(path);
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: normalizedPath,
+    },
+    openGraph: {
+      title,
+      description,
+      url: normalizedPath,
+      siteName: SITE_NAME,
+      locale: 'ko_KR',
+      type,
+      images: [{ url: '/favicon.ico' }],
+    },
+    twitter: {
+      card: 'summary',
+      title,
+      description,
+      images: ['/favicon.ico'],
+    },
+  };
+}

--- a/src/types/post.d.ts
+++ b/src/types/post.d.ts
@@ -1,9 +1,9 @@
 interface PostMeta {
   index: number;
   title: string;
-  description: string;
+  description?: string;
   date: string;
-  tag?: string;
+  tag?: string | string[];
 }
 
 interface Post {


### PR DESCRIPTION
## DEV-20260415-002

### Bug fix: missing post handling and SEO metadata stabilization
- invalid post slugs now return `notFound()` 404 instead of throwing on missing content
- page-level metadata was added for home, posts list, post detail, and resume pages
- shared canonical, Open Graph, and Twitter metadata generation was centralized in `src/lib/seo.ts`
- root layout now sets `html lang="ko"` and metadata base defaults for share/crawl tags

### Bug fix: sitemap coverage and post frontmatter normalization
- sitemap generation now includes `/posts` plus post detail URLs from the configured `POSTS_DIR`
- post frontmatter dates are normalized to strings so valid post pages do not 500 when gray-matter parses YAML dates as `Date`
- post metadata typing now matches optional descriptions and array tags used by content

### Tests
- 신규: 없음 (기존 테스트 스위트 없음)
- 전체: `npm run lint` 통과 (기존 unrelated warning 2건), `POSTS_DIR=<tmp> npm run build` 통과
- Build: 성공

### Changed files
- `next-sitemap.config.js`
- `src/app/layout.tsx`
- `src/app/page.tsx`
- `src/app/posts/[slug]/page.tsx`
- `src/app/posts/page.tsx`
- `src/app/resume/page.tsx`
- `src/lib/posts.ts`
- `src/lib/seo.ts` (new)
- `src/types/post.d.ts`
